### PR TITLE
yaml merge key handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,17 +121,9 @@ jobs:
           [[ "${{ matrix.name }}" == windows-* ]] && ext=".exe"
           bin="target/${{ matrix.target }}/release/yq${ext}"
           strip "$bin" || true
-
-          #version=$(cat VERSION)
           dst="yq-${{ matrix.target }}"
           mkdir "$dst"
-
-          mkdir -p "target/release"
-          cp "$bin" "target/release/" # workaround for cargo-deb silliness with targets
-
           cp "$bin" "$dst/"
-          #cp -r README.md LICENSE completions yq.1 "$dst/"
-          cp README.md LICENSE "$dst/"
 
       - name: Archive (tar)
         if: '! startsWith(matrix.name, ''windows-'')'
@@ -184,7 +176,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           generate_release_notes: true
-          #draft: true
           fail_on_unmatched_files: true
           files: |
             yq-*.tar.xz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,7 +495,6 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
- "serde",
  "serde_json",
  "serde_yaml",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
+ "serde",
  "serde_json",
  "serde_yaml",
  "toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "2cc66a619ed80bf7a0f6b17dd063a84b88f6dea1813737cf469aef1d081142c2"
 dependencies = [
  "itoa",
  "ryu",
@@ -371,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.14"
+version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 [profile.release]
 lto = true
 panic = "abort"
-strip = "symbols"
+#strip = "symbols"
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/{ version }/yq-{ target }{ archive-suffix }"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ toml = { version = "0.7.6", features = ["display"] }
 serde_yaml = "0.9.25"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-serde = "1.0.188"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ toml = { version = "0.7.6", features = ["display"] }
 serde_yaml = "0.9.25"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+serde = "1.0.188"
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cargo binstall whyq
 - arbitrary `jq` usage on yaml/toml input with same syntax (args passed along to `jq` with json converted input)
 - drop-in replacement to [python-yq](https://kislyuk.github.io/yq/) (e.g. provides: yq)
 - handles multidoc **yaml** input (vector of documents returned when multiple docs found)
-- handles duplicate yaml keys and [yaml merge keys](https://yaml.org/type/merge.html)
+- handles [yaml merge keys](https://yaml.org/type/merge.html)
 - handles **toml** input (from [Table](https://docs.rs/toml/latest/toml/#parsing-toml))
 - unpacks yaml tags (input is [singleton mapped](https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map/index.html) [recursively](https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map_recursive/index.html))
 - allows converting `jq` output to YAML (`-y`) or TOML (`-t`)

--- a/README.md
+++ b/README.md
@@ -25,11 +25,10 @@ cargo binstall whyq
 - arbitrary `jq` usage on yaml/toml input with same syntax (args passed along to `jq` with json converted input)
 - drop-in replacement to [python-yq](https://kislyuk.github.io/yq/) (e.g. provides: yq)
 - handles multidoc **yaml** input (vector of documents returned when multiple docs found)
-- handles [yaml merge keys](https://yaml.org/type/merge.html)
+- handles [yaml merge keys](https://yaml.org/type/merge.html) and expands yaml tags (via `serde_yaml`)
 - handles **toml** input (from [Table](https://docs.rs/toml/latest/toml/#parsing-toml))
-- unpacks yaml tags (input is [singleton mapped](https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map/index.html) [recursively](https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map_recursive/index.html))
 - allows converting `jq` output to YAML (`-y`) or TOML (`-t`)
-- uses <1MB in your CI image
+- <1MB in binary size (for your small cloud CI images)
 
 ## YAML Input
 Use as [jq](https://jqlang.github.io/jq/tutorial/) either via stdin:
@@ -130,4 +129,5 @@ If you pass on `-r` for raw output, then this will not be parseable as json.
 - Only YAML/TOML input/output is supported (no XML).
 - Shells out to `jq` (only supports what your jq version supports).
 - Does not provide rich `-h` or `--help` output (assumes you can use `jq --help` or `man jq`).
-- Does not preserve [YAML tags](https://yaml.org/spec/1.2-old/spec.html#id2764295) (input is [singleton mapped](https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map/index.html) [recursively](https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map_recursive/index.html)).
+- Does not preserve [YAML tags](https://yaml.org/spec/1.2-old/spec.html#id2764295) (input is [singleton mapped](https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map/index.html) [recursively](https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map_recursive/index.html) and then [apply_merged](https://docs.rs/serde_yaml/latest/serde_yaml/value/enum.Value.html#method.apply_merge) before `jq`)
+- Does [not support duplicate keys](https://github.com/clux/whyq/issues/14) in the input document

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ cargo binstall whyq
 - arbitrary `jq` usage on yaml/toml input with same syntax (args passed along to `jq` with json converted input)
 - drop-in replacement to [python-yq](https://kislyuk.github.io/yq/) (e.g. provides: yq)
 - handles multidoc **yaml** input (vector of documents returned when multiple docs found)
+- handles duplicate yaml keys and [yaml merge keys](https://yaml.org/type/merge.html)
 - handles **toml** input (from [Table](https://docs.rs/toml/latest/toml/#parsing-toml))
 - unpacks yaml tags (input is [singleton mapped](https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map/index.html) [recursively](https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map_recursive/index.html))
 - allows converting `jq` output to YAML (`-y`) or TOML (`-t`)

--- a/test/circle.yml
+++ b/test/circle.yml
@@ -1,0 +1,58 @@
+version: 2.1
+
+definitions:
+  steps:
+    - step: &build_binary
+        name: Build binary
+        command: chmod a+w . && cargo build --release
+    - step: &versions
+        name: Version information
+        command: rustc --version; cargo --version; rustup --version
+
+  filters:
+    on_tag: &on_tag
+      tags:
+        only: /v[0-9]+(\.[0-9]+)*/
+      branches:
+        ignore: /.*/
+    on_every_commit: &on_every_commit
+      tags:
+        only: /.*/
+
+jobs:
+  build:
+    docker:
+      - image: clux/muslrust:stable
+    resource_class: xlarge
+    environment:
+      IMAGE_NAME: whyq
+    steps:
+      - checkout
+      - run: *versions
+      - run: *build_binary
+      - run: echo versions
+
+  release:
+    docker:
+      - image: clux/muslrust:stable
+    resource_class: xlarge
+    steps:
+      - checkout
+      - run: *versions
+      - run: *build_binary
+      - upload:
+          source: "target/x86_64-unknown-linux-musl/release/${IMAGE_NAME}"
+          binary_name: "${IMAGE_NAME}"
+          version: "${CIRCLE_TAG}"
+          arch: "x86_64-unknown-linux-musl"
+
+workflows:
+  version: 2
+  my_flow:
+    jobs:
+      - build:
+          filters:
+            <<: *on_every_commit
+      - release:
+          filters:
+             <<: *on_tag

--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -57,3 +57,11 @@
   run yq -i=toml '.dependencies.clap.features' -c < Cargo.toml
   echo "$output" && echo "$output" | grep '["cargo","derive"]'
 }
+
+@test "yaml_merge" {
+  run yq -m '.workflows.my_flow.jobs[0].build' -c < test/circle.yml
+  echo "$output" && echo "$output" | grep '{"filters":{"tags":{"only":"/.*/"}}}'
+
+  run yq -m '.jobs.build.steps[1].run.name' -r < test/circle.yml
+  echo "$output" && echo "$output" | grep "Version information"
+}

--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -59,9 +59,9 @@
 }
 
 @test "yaml_merge" {
-  run yq -m '.workflows.my_flow.jobs[0].build' -c < test/circle.yml
+  run yq -x '.workflows.my_flow.jobs[0].build' -c < test/circle.yml
   echo "$output" && echo "$output" | grep '{"filters":{"tags":{"only":"/.*/"}}}'
 
-  run yq -m '.jobs.build.steps[1].run.name' -r < test/circle.yml
+  run yq -x '.jobs.build.steps[1].run.name' -r < test/circle.yml
   echo "$output" && echo "$output" | grep "Version information"
 }

--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -59,9 +59,9 @@
 }
 
 @test "yaml_merge" {
-  run yq -x '.workflows.my_flow.jobs[0].build' -c < test/circle.yml
+  run yq '.workflows.my_flow.jobs[0].build' -c < test/circle.yml
   echo "$output" && echo "$output" | grep '{"filters":{"tags":{"only":"/.*/"}}}'
 
-  run yq -x '.jobs.build.steps[1].run.name' -r < test/circle.yml
+  run yq '.jobs.build.steps[1].run.name' -r < test/circle.yml
   echo "$output" && echo "$output" | grep "Version information"
 }

--- a/yq.rs
+++ b/yq.rs
@@ -192,6 +192,7 @@ mod test {
             Self {
                 yaml_output: yaml,
                 toml_output: false,
+                yaml_merge: false,
                 input: Input::Yaml,
                 extra: args.into_iter().map(|x| x.to_string()).collect(),
             }

--- a/yq.rs
+++ b/yq.rs
@@ -38,9 +38,21 @@ struct Args {
     #[arg(short = 'i', long, value_enum, default_value_t)]
     input: Input,
 
-    /// Expand tags such as YAML <<: merge tags
-    #[arg(short = 'x', default_value = "false")] // Ideally should only work if input == Input::yaml
-    expand: bool,
+    /// Do not expand tags
+    ///
+    /// This probably is not the desired behaviour for yaml given we are already
+    /// recursively singleton mapping the documents.
+    /// This is only an escape-hatch in case of early bugs, and hopefully will be removed
+    #[arg(long = "no-expand", default_value = "false")]
+    no_expand: bool,
+
+    /// Partially expand? testing..
+    #[arg(
+        long = "partial-expand",
+        default_value = "false",
+        conflicts_with = "no_expand"
+    )]
+    partial_expand: bool,
 
     /// Arguments passed to jq
     ///
@@ -76,13 +88,19 @@ impl Args {
 
         let mut docs: Vec<serde_json::Value> = vec![];
         for doc in yaml_de {
-            let json_value: serde_json::Value = if self.expand {
+            let json_value: serde_json::Value = if self.no_expand {
+                use serde::Deserialize;
+                debug!("no expanding");
+                serde_json::Value::deserialize(doc)?
+            } else if self.partial_expand {
+                debug!("some expanding");
+                singleton_map_recursive::deserialize(doc)?
+            } else {
+                debug!("full expanding");
                 let mut yaml_doc: serde_yaml::Value = singleton_map_recursive::deserialize(doc)?;
                 yaml_doc.apply_merge()?;
                 let yaml_ser = serde_yaml::to_string(&yaml_doc)?;
                 serde_yaml::from_str(&yaml_ser)?
-            } else {
-                singleton_map_recursive::deserialize(doc)?
             };
             docs.push(json_value);
         }
@@ -192,7 +210,8 @@ mod test {
             Self {
                 yaml_output: yaml,
                 toml_output: false,
-                expand: false,
+                no_expand: false,
+                partial_expand: false, // TODO: cleanup
                 input: Input::Yaml,
                 extra: args.into_iter().map(|x| x.to_string()).collect(),
             }

--- a/yq.rs
+++ b/yq.rs
@@ -72,7 +72,11 @@ impl Args {
 
         let mut docs: Vec<serde_json::Value> = vec![];
         for doc in yaml_de {
-            docs.push(singleton_map_recursive::deserialize(doc)?);
+            let mut yaml_doc: serde_yaml::Value = singleton_map_recursive::deserialize(doc)?;
+            yaml_doc.apply_merge()?;
+            let yaml_ser = serde_yaml::to_string(&yaml_doc)?;
+            let json_value: serde_json::Value = serde_json::from_str(&yaml_ser)?;
+            docs.push(json_value);
         }
         debug!("found {} documents", docs.len());
         // if there is 1 or 0 documents, do not return as nested documents

--- a/yq.rs
+++ b/yq.rs
@@ -38,9 +38,9 @@ struct Args {
     #[arg(short = 'i', long, value_enum, default_value_t)]
     input: Input,
 
-    /// Apply YAML merge tags
-    #[arg(short = 'm', long, default_value = "false")] // TODO: yaml only? different input format?
-    yaml_merge: bool,
+    /// Expand tags such as YAML <<: merge tags
+    #[arg(short = 'x', default_value = "false")] // Ideally should only work if input == Input::yaml
+    expand: bool,
 
     /// Arguments passed to jq
     ///
@@ -76,7 +76,7 @@ impl Args {
 
         let mut docs: Vec<serde_json::Value> = vec![];
         for doc in yaml_de {
-            let json_value: serde_json::Value = if self.yaml_merge {
+            let json_value: serde_json::Value = if self.expand {
                 let mut yaml_doc: serde_yaml::Value = singleton_map_recursive::deserialize(doc)?;
                 yaml_doc.apply_merge()?;
                 let yaml_ser = serde_yaml::to_string(&yaml_doc)?;
@@ -192,7 +192,7 @@ mod test {
             Self {
                 yaml_output: yaml,
                 toml_output: false,
-                yaml_merge: false,
+                expand: false,
                 input: Input::Yaml,
                 extra: args.into_iter().map(|x| x.to_string()).collect(),
             }


### PR DESCRIPTION
have it working under an optional flag that only works with yaml input.

not sure if this is enough to warrant a different input enum, or if it just needs another flag (that doesn't clash with jq) that only works in the yaml mode..

maybe we should just always do this for yaml tbh - it makes no sense to pass through tags to jq.