### PR TITLE
inline compatible `jq` args to support `--in-place`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Note that YAML is the assumed default input format and primary usage case (and w
 
 ## TOML Input
 
-Using say `Cargo.toml` from this repo as input, and aliasing `tq='yq -i=toml'`:
+Using say `Cargo.toml` from this repo as input, and aliasing `tq='yq --input=toml'`:
 
 ```sh
 $ tq '.package.categories[]' -r < Cargo.toml

--- a/README.md
+++ b/README.md
@@ -114,6 +114,6 @@ If you pass on `-r` for raw output, then this will not be parseable as json.
 
 - Only YAML/TOML input/output is supported (no XML).
 - Shells out to `jq` (only supports what your jq version supports).
-- Does not provide rich `-h` or `--help` output (assumes you can use `jq --help` or `man jq`).
 - Does not preserve [YAML tags](https://yaml.org/spec/1.2-old/spec.html#id2764295) (input is [singleton mapped](https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map/index.html) [recursively](https://docs.rs/serde_yaml/latest/serde_yaml/with/singleton_map_recursive/index.html) and then [apply_merged](https://docs.rs/serde_yaml/latest/serde_yaml/value/enum.Value.html#method.apply_merge) before `jq`)
+- Does not preserve (or allow customizing) indentation in the output (supported in [serde_json](https://docs.rs/serde_json/latest/serde_json/ser/struct.PrettyFormatter.html), but unsupported in [serde_yaml](https://github.com/dtolnay/serde-yaml/issues/337))
 - Does [not support duplicate keys](https://github.com/clux/whyq/issues/14) in the input document

--- a/README.md
+++ b/README.md
@@ -104,20 +104,6 @@ Escaping keys with slashes etc in them:
 yq -y '.updates[] | select(.["package-ecosystem"] == "cargo") | .groups' .github/dependabot.yml
 ```
 
-## Argument Priority
-All arguments except output selectors such as `-y` or `-t`, and the input arg `-i` are passed on to `jq`.
-
-**Convention**; put `yq` arguments at the front, and `jq` arguments at the back. If it complains put a `--` to separate the argument groups.
-
-**Explaination**: arg parsers are generally struggling with positional leftover arguments containing flags because they lack concepts of "our flags" and "their flags" and will try to match them together. This means combining yq and jq flags into a single arg will not work, and why a convention to explicitly separate the two args exists. Normally the separation is inferred automatically if you put a normal jq query in the middle, but if you don't have any normal positional value arg, you can put a `--` trailing vararg delimiter to indicate that all remaining flags are for `jq`;
-
-```sh
-yq -y -c '.[3].kind' < test/deploy.yaml # fails; implicit separation is not detected for a flag first
-yq -y '.[3].kind' -c < test/deploy.yaml # works; implicit separation detected after positional
-yq -yc '.[3].kind' < test/deploy.yaml # fails; cannot combine of yq and jq args
-yq -y -- -c '.[3].kind' < test/deploy.yaml # works; explicit separation
-```
-
 ## Output Caveats
 
 Output formatting such as `-y` for YAML or `-t` for TOML will require the output from `jq` to be parseable json.

--- a/test/grafana.yaml
+++ b/test/grafana.yaml
@@ -1,168 +1,164 @@
----
-# Source: promstack/charts/kube-prometheus-stack/charts/grafana/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app.kubernetes.io/instance: promstack
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/version: 10.1.0
+    helm.sh/chart: grafana-6.59.0
   name: promstack-grafana
   namespace: monitoring
-  labels:
-    helm.sh/chart: grafana-6.59.0
-    app.kubernetes.io/name: grafana
-    app.kubernetes.io/instance: promstack
-    app.kubernetes.io/version: "10.1.0"
-    app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/name: grafana
       app.kubernetes.io/instance: promstack
+      app.kubernetes.io/name: grafana
   strategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: grafana
         app.kubernetes.io/instance: promstack
+        app.kubernetes.io/name: grafana
     spec:
-      serviceAccountName: promstack-grafana
       automountServiceAccountToken: true
+      containers:
+      - env:
+        - name: METHOD
+          value: WATCH
+        - name: LABEL
+          value: grafana_dashboard
+        - name: LABEL_VALUE
+          value: '1'
+        - name: FOLDER
+          value: /tmp/dashboards
+        - name: RESOURCE
+          value: configmap
+        - name: NAMESPACE
+          value: ALL
+        - name: FOLDER_ANNOTATION
+          value: grafana_folder
+        - name: REQ_METHOD
+          value: POST
+        image: quay.io/kiwigrid/k8s-sidecar:1.24.6
+        imagePullPolicy: IfNotPresent
+        name: grafana-sc-dashboard
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /tmp/dashboards
+          name: sc-dashboard-volume
+      - env:
+        - name: METHOD
+          value: WATCH
+        - name: LABEL
+          value: grafana_datasource
+        - name: LABEL_VALUE
+          value: '1'
+        - name: FOLDER
+          value: /etc/grafana/provisioning/datasources
+        - name: RESOURCE
+          value: secret
+        - name: REQ_METHOD
+          value: POST
+        image: quay.io/kiwigrid/k8s-sidecar:1.24.6
+        imagePullPolicy: IfNotPresent
+        name: grafana-sc-datasources
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/grafana/provisioning/datasources
+          name: sc-datasources-volume
+      - env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: GF_PATHS_DATA
+          value: /var/lib/grafana/
+        - name: GF_PATHS_LOGS
+          value: /var/log/grafana
+        - name: GF_PATHS_PLUGINS
+          value: /var/lib/grafana/plugins
+        - name: GF_PATHS_PROVISIONING
+          value: /etc/grafana/provisioning
+        image: docker.io/grafana/grafana:10.1.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 10
+          httpGet:
+            path: /api/health
+            port: 3000
+          initialDelaySeconds: 60
+          timeoutSeconds: 30
+        name: grafana
+        ports:
+        - containerPort: 3000
+          name: grafana
+          protocol: TCP
+        - containerPort: 9094
+          name: gossip-tcp
+          protocol: TCP
+        - containerPort: 9094
+          name: gossip-udp
+          protocol: UDP
+        readinessProbe:
+          httpGet:
+            path: /api/health
+            port: 3000
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/grafana/grafana.ini
+          name: config
+          subPath: grafana.ini
+        - mountPath: /var/lib/grafana
+          name: storage
+        - mountPath: /etc/grafana/provisioning/datasources/datasources.yaml
+          name: config
+          subPath: datasources.yaml
+        - mountPath: /tmp/dashboards
+          name: sc-dashboard-volume
+        - mountPath: /etc/grafana/provisioning/dashboards/sc-dashboardproviders.yaml
+          name: sc-dashboard-provider
+          subPath: provider.yaml
+        - mountPath: /etc/grafana/provisioning/datasources
+          name: sc-datasources-volume
+      enableServiceLinks: true
       securityContext:
         fsGroup: 472
         runAsGroup: 472
         runAsNonRoot: true
         runAsUser: 472
-      enableServiceLinks: true
-      containers:
-        - name: grafana-sc-dashboard
-          image: "quay.io/kiwigrid/k8s-sidecar:1.24.6"
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: METHOD
-              value: WATCH
-            - name: LABEL
-              value: "grafana_dashboard"
-            - name: LABEL_VALUE
-              value: "1"
-            - name: FOLDER
-              value: "/tmp/dashboards"
-            - name: RESOURCE
-              value: "configmap"
-            - name: NAMESPACE
-              value: "ALL"
-            - name: FOLDER_ANNOTATION
-              value: "grafana_folder"
-            - name: REQ_METHOD
-              value: POST
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            seccompProfile:
-              type: RuntimeDefault
-          volumeMounts:
-            - name: sc-dashboard-volume
-              mountPath: "/tmp/dashboards"
-        - name: grafana-sc-datasources
-          image: "quay.io/kiwigrid/k8s-sidecar:1.24.6"
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: METHOD
-              value: WATCH
-            - name: LABEL
-              value: "grafana_datasource"
-            - name: LABEL_VALUE
-              value: "1"
-            - name: FOLDER
-              value: "/etc/grafana/provisioning/datasources"
-            - name: RESOURCE
-              value: "secret"
-            - name: REQ_METHOD
-              value: POST
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            seccompProfile:
-              type: RuntimeDefault
-          volumeMounts:
-            - name: sc-datasources-volume
-              mountPath: "/etc/grafana/provisioning/datasources"
-        - name: grafana
-          image: "docker.io/grafana/grafana:10.1.0"
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-              - ALL
-            seccompProfile:
-              type: RuntimeDefault
-          volumeMounts:
-            - name: config
-              mountPath: "/etc/grafana/grafana.ini"
-              subPath: grafana.ini
-            - name: storage
-              mountPath: "/var/lib/grafana"
-            - name: config
-              mountPath: "/etc/grafana/provisioning/datasources/datasources.yaml"
-              subPath: "datasources.yaml"
-            - name: sc-dashboard-volume
-              mountPath: "/tmp/dashboards"
-            - name: sc-dashboard-provider
-              mountPath: "/etc/grafana/provisioning/dashboards/sc-dashboardproviders.yaml"
-              subPath: provider.yaml
-            - name: sc-datasources-volume
-              mountPath: "/etc/grafana/provisioning/datasources"
-          ports:
-            - name: grafana
-              containerPort: 3000
-              protocol: TCP
-            - name: gossip-tcp
-              containerPort: 9094
-              protocol: TCP
-            - name: gossip-udp
-              containerPort: 9094
-              protocol: UDP
-          env:
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: GF_PATHS_DATA
-              value: /var/lib/grafana/
-            - name: GF_PATHS_LOGS
-              value: /var/log/grafana
-            - name: GF_PATHS_PLUGINS
-              value: /var/lib/grafana/plugins
-            - name: GF_PATHS_PROVISIONING
-              value: /etc/grafana/provisioning
-          livenessProbe:
-            failureThreshold: 10
-            httpGet:
-              path: /api/health
-              port: 3000
-            initialDelaySeconds: 60
-            timeoutSeconds: 30
-          readinessProbe:
-            httpGet:
-              path: /api/health
-              port: 3000
+      serviceAccountName: promstack-grafana
       volumes:
-        - name: config
-          configMap:
-            name: promstack-grafana
-        - name: storage
-          emptyDir: {}
-        - name: sc-dashboard-volume
-          emptyDir:
-            {}
-        - name: sc-dashboard-provider
-          configMap:
-            name: promstack-grafana-config-dashboards
-        - name: sc-datasources-volume
-          emptyDir:
-            {}
+      - configMap:
+          name: promstack-grafana
+        name: config
+      - emptyDir: {}
+        name: storage
+      - emptyDir: {}
+        name: sc-dashboard-volume
+      - configMap:
+          name: promstack-grafana-config-dashboards
+        name: sc-dashboard-provider
+      - emptyDir: {}
+        name: sc-datasources-volume

--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -51,10 +51,10 @@
 }
 
 @test "toml" {
-  run yq -i=toml -y '.package.edition' -r < Cargo.toml
+  run yq --input=toml -y '.package.edition' -r < Cargo.toml
   echo "$output" && echo "$output" | grep '2021'
 
-  run yq -i=toml '.dependencies.clap.features' -c < Cargo.toml
+  run yq --input=toml '.dependencies.clap.features' -c < Cargo.toml
   echo "$output" && echo "$output" | grep '["cargo","derive"]'
 }
 

--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -47,7 +47,7 @@
     skip # ci is fun
   fi
   run yq
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 2 ]
 }
 
 @test "toml" {

--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -65,3 +65,9 @@
   run yq '.jobs.build.steps[1].run.name' -r < test/circle.yml
   echo "$output" && echo "$output" | grep "Version information"
 }
+
+@test "inplace" {
+  run yq -yi '.kind = "Hahah"' test/grafana.yaml
+  run yq -r .kind test/grafana.yaml
+  echo "$output" && echo "$output" | grep "Hahah"
+}

--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -72,3 +72,8 @@
   echo "$output" && echo "$output" | grep "Hahah"
   yq -yi '.kind = "Deployment"' test/grafana.yaml # undo
 }
+
+@test "join" {
+  run yq -j '.spec.template.spec.containers[].image' test/grafana.yaml
+  echo "$output" && echo "$output" | grep "quay.io/kiwigrid/k8s-sidecar:1.24.6quay.io/kiwigrid/k8s-sidecar:1.24.6docker.io/grafana/grafana:10.1.0"
+}

--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -70,4 +70,5 @@
   run yq -yi '.kind = "Hahah"' test/grafana.yaml
   run yq -r .kind test/grafana.yaml
   echo "$output" && echo "$output" | grep "Hahah"
+  yq -yi '.kind = "Deployment"' test/grafana.yaml # undo
 }

--- a/yq.rs
+++ b/yq.rs
@@ -69,7 +69,7 @@ struct Args {
     ///
     /// This is unlikely to work with yaml or toml output because it requires
     /// that the jq -r output is deserializable into the desired output format.
-    #[arg(short = 'c', long, default_value = "false")]
+    #[arg(short = 'j', long, default_value = "false")]
     join_output: bool,
 }
 

--- a/yq.rs
+++ b/yq.rs
@@ -213,7 +213,7 @@ fn main() -> Result<()> {
     let output = args.output(stdout)?;
     if args.in_place {
         let f = args.file.unwrap(); // required
-        std::fs::write(f, output)?;
+        std::fs::write(f, output + "\n")?;
     } else {
         println!("{}", output);
     }

--- a/yq.rs
+++ b/yq.rs
@@ -25,7 +25,7 @@ enum Input {
 /// yq '.[].kind' -r < manifest.yml
 ///
 /// yq -y '.[2].metadata' < manifest.yml
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Default)]
 #[command(author, version, about)]
 struct Args {
     /// Transcode jq JSON output into YAML and emit it
@@ -35,20 +35,41 @@ struct Args {
     #[arg(short = 't', long, default_value = "false", conflicts_with = "yaml_output")]
     toml_output: bool,
     /// Input format
-    #[arg(short = 'i', long, value_enum, default_value_t)]
+    #[arg(long, value_enum, default_value_t)]
     input: Input,
 
-    /// Arguments passed to jq
+    /// Inplace editing
+    #[arg(short, long, default_value = "false", requires = "file")]
+    in_place: bool,
+
+    #[arg(default_value = "false")]
+    file: Option<PathBuf>,
+
+    // ----- jq arguments
+    /// Output strings without escapes and quotes
+    #[arg(short, long, default_value = "false")]
+    raw_output: bool,
+
+    /// Compact instead of pretty-printed output
     ///
-    /// These arguments must be trailing and come after the flags above.
-    /// Do not join yq flags nad jq flags (such as `-yc`; use `-y -- -c`)
+    /// This is unlikely to work with yaml or toml output because it requires
+    /// that the jq -c output is deserializable into the desired output format.
+    #[arg(short = 'c', long, default_value = "false")]
+    compact_output: bool,
+
+    /// Output strings without escapes and quotes
     ///
-    /// If the jq args start with a flag, you need an explicit trailing vararg marker (--).
-    /// This is not needed if the first vararg is a jq query or a normal positional value.
+    /// This is unlikely to work with yaml or toml output because it requires
+    /// that the jq -r output is deserializable into the desired output format.
+    #[arg(short = 'r', long, default_value = "false")]
+    raw_output: bool,
+
+    /// Output strings without escapes and quotes, without newlines after each output
     ///
-    /// The last arg can be a file, but stdin will be preferred when present.
-    #[arg(trailing_var_arg = true)]
-    extra: Vec<String>,
+    /// This is unlikely to work with yaml or toml output because it requires
+    /// that the jq -r output is deserializable into the desired output format.
+    #[arg(short = 'c', long, default_value = "false")]
+    join_output: bool,
 }
 
 impl Args {

--- a/yq.rs
+++ b/yq.rs
@@ -211,7 +211,12 @@ fn main() -> Result<()> {
     let input = args.read_input()?;
     let stdout = args.shellout(input)?;
     let output = args.output(stdout)?;
-    println!("{}", output);
+    if args.in_place {
+        let f = args.file.unwrap(); // required
+        std::fs::write(f, output)?;
+    } else {
+        println!("{}", output);
+    }
     Ok(())
 }
 

--- a/yq.rs
+++ b/yq.rs
@@ -43,29 +43,30 @@ struct Args {
     #[arg(short, long, default_value = "false", requires = "file")]
     in_place: bool,
 
-    /// Query to be sent to jq
+    /// Query to be sent to jq (see https://jqlang.github.io/jq/manual/)
     #[arg()]
     jq_query: String,
 
+    /// Optional file to read (instead of stdin) in the chosen --input format
     #[arg()]
     file: Option<PathBuf>,
 
     // ----- jq arguments
-    /// Compact instead of pretty-printed output
+    /// Compact instead of pretty-printed output (json only)
     ///
     /// This is unlikely to work with yaml or toml output because it requires
     /// that the jq -c output is deserializable into the desired output format.
     #[arg(short = 'c', long, default_value = "false")]
     compact_output: bool,
 
-    /// Output strings without escapes and quotes
+    /// Output strings without escapes and quotes (json only)
     ///
     /// This is unlikely to work with yaml or toml output because it requires
     /// that the jq -r output is deserializable into the desired output format.
     #[arg(short = 'r', long, default_value = "false")]
     raw_output: bool,
 
-    /// Output strings without escapes and quotes, without newlines after each output
+    /// Output strings without escapes and quotes, without newlines after each output (json only)
     ///
     /// This is unlikely to work with yaml or toml output because it requires
     /// that the jq -r output is deserializable into the desired output format.

--- a/yq.rs
+++ b/yq.rs
@@ -43,10 +43,11 @@ struct Args {
     #[arg(short, long, default_value = "false", requires = "file")]
     in_place: bool,
 
-    #[arg(default_value = "")]
+    /// Query to be sent to jq
+    #[arg()]
     jq_query: String,
 
-    #[arg(default_value = "false")]
+    #[arg()]
     file: Option<PathBuf>,
 
     // ----- jq arguments


### PR DESCRIPTION
- [x] preliminary work fixing trailing vararg quirks by inlining common `jq` flags inside our args
- [x] add explicit file arg to help this and fix awkward stdin detection
- [x] rename `-i` to `--input` (people can `alias tq=yq --input=toml` as a one time thing where it's more readable with the full arg)
- [x] add new `-i` / `--in-place` that requires `file` arg