### PR TITLE
Allow eliding the jq_query

### DIFF
--- a/test/yq.test.bats
+++ b/test/yq.test.bats
@@ -47,7 +47,7 @@
     skip # ci is fun
   fi
   run yq
-  [ "$status" -eq 2 ]
+  [ "$status" -eq 1 ]
 }
 
 @test "toml" {

--- a/yq.rs
+++ b/yq.rs
@@ -69,8 +69,10 @@ struct Args {
     in_place: bool,
 
     /// Query to be sent to jq (see https://jqlang.github.io/jq/manual/)
+    ///
+    /// Default "."
     #[arg()]
-    jq_query: String,
+    jq_query: Option<String>,
 
     /// Optional file to read (instead of stdin) in the chosen --input format
     #[arg()]
@@ -105,7 +107,7 @@ struct Args {
 
 impl Args {
     fn jq_args(&self) -> Vec<String> {
-        let mut args = vec![self.jq_query.clone()];
+        let mut args = vec![self.jq_query.clone().unwrap_or_else(|| ".".into())];
         if self.compact_output {
             args.push("-c".into());
         }
@@ -292,7 +294,7 @@ mod test {
     fn file_input_both_outputs() -> Result<()> {
         init_env_tracing_stderr()?;
         let mut args = Args {
-            jq_query: ".[2].metadata".into(),
+            jq_query: Some(".[2].metadata".into()),
             compact_output: true,
             output: Output::Jq,
             file: Some("test/deploy.yaml".into()),

--- a/yq.rs
+++ b/yq.rs
@@ -107,7 +107,10 @@ struct Args {
 
 impl Args {
     fn jq_args(&self) -> Vec<String> {
-        let mut args = vec![self.jq_query.clone().unwrap_or_else(|| ".".into())];
+        let mut args = vec![];
+        if let Some(query) = &self.jq_query {
+            args.push(query.into())
+        }
         if self.compact_output {
             args.push("-c".into());
         }


### PR DESCRIPTION
Both `jq` and python-yq supports eliding the `jq_query` in favour of the implicit '.' default, so doing the same here