### PR TITLE
Avoid sigpipe errors without pulling in libc

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,7 +25,7 @@ jobs:
           - macos
         toolchain:
           - stable
-          - 1.70.0
+          - 1.76.0
 
     name: Test on ${{ matrix.platform }} with ${{ matrix.toolchain }}
     runs-on: "${{ matrix.platform }}-latest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 readme = "./README.md"
 repository = "https://github.com/clux/whyq"
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.76.0"
 categories = ["command-line-utilities", "parsing"]
 
 

--- a/yq.rs
+++ b/yq.rs
@@ -296,7 +296,9 @@ fn main() -> Result<()> {
         let f = args.file.unwrap(); // required
         std::fs::write(f, output + "\n")?;
     } else {
-        println!("{}", output);
+        // write result to stdout ignoring SIGPIPE errors
+        // https://github.com/rust-lang/rust/issues/46016
+        let _ = writeln!(std::io::stdout(), "{output}");
     }
     Ok(())
 }


### PR DESCRIPTION
without this you get these lovely errors when dropping the end side of the pipe:

```sh
$ kgp -oyaml | yq | false
E0306 21:22:45.049441  149251 memcache.go:265] couldn't get current server API group list: Get "https://0.0.0.0:38167/api?timeout=32s": dial tcp 0.0.0.0:38167: connect: connection refused
E0306 21:22:45.050078  149251 memcache.go:265] couldn't get current server API group list: Get "https://0.0.0.0:38167/api?timeout=32s": dial tcp 0.0.0.0:38167: connect: connection refused
E0306 21:22:45.050996  149251 memcache.go:265] couldn't get current server API group list: Get "https://0.0.0.0:38167/api?timeout=32s": dial tcp 0.0.0.0:38167: connect: connection refused
E0306 21:22:45.052296  149251 memcache.go:265] couldn't get current server API group list: Get "https://0.0.0.0:38167/api?timeout=32s": dial tcp 0.0.0.0:38167: connect: connection refused
E0306 21:22:45.052513  149251 memcache.go:265] couldn't get current server API group list: Get "https://0.0.0.0:38167/api?timeout=32s": dial tcp 0.0.0.0:38167: connect: connection refused
The connection to the server 0.0.0.0:38167 was refused - did you specify the right host or port?
thread 'main' panicked at 'failed printing to stdout: Broken pipe (os error 32)', library/std/src/io/stdio.rs:1019:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/std/src/panicking.rs:593:5
   1: core::panicking::panic_fmt
             at /rustc/d5c2e9c342b358556da91d61ed4133f6f50fc0c3/library/core/src/panicking.rs:67:14
   2: yq::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
zsh: exit 1                         kubectl get pod -oyaml |
zsh: IOT instruction (core dumped)  yq
```

after:

```sh
kgp -oyaml | yq | false
E0306 21:23:04.257852  149917 memcache.go:265] couldn't get current server API group list: Get "https://0.0.0.0:38167/api?timeout=32s": dial tcp 0.0.0.0:38167: connect: connection refused
E0306 21:23:04.258105  149917 memcache.go:265] couldn't get current server API group list: Get "https://0.0.0.0:38167/api?timeout=32s": dial tcp 0.0.0.0:38167: connect: connection refused
E0306 21:23:04.259471  149917 memcache.go:265] couldn't get current server API group list: Get "https://0.0.0.0:38167/api?timeout=32s": dial tcp 0.0.0.0:38167: connect: connection refused
E0306 21:23:04.259666  149917 memcache.go:265] couldn't get current server API group list: Get "https://0.0.0.0:38167/api?timeout=32s": dial tcp 0.0.0.0:38167: connect: connection refused
E0306 21:23:04.260945  149917 memcache.go:265] couldn't get current server API group list: Get "https://0.0.0.0:38167/api?timeout=32s": dial tcp 0.0.0.0:38167: connect: connection refused
The connection to the server 0.0.0.0:38167 was refused - did you specify the right host or port?
```

kubernetes logs unrelated, just needed a command that took a little time.

could have pulled in libc to do the sigpipe ignoring like we do in kopium:
https://github.com/kube-rs/kopium/blob/bb163bbc2f59dd9efbf23fd2c48c63091fb6a112/src/main.rs#L109-L114
but this felt overkill here (we only do one print) and nice to skip the dep. particularly if rust is actually going to give a better solution to this at some point.